### PR TITLE
fixed logging of signin and reactivated analysis

### DIFF
--- a/R/app_analytics.R
+++ b/R/app_analytics.R
@@ -31,7 +31,7 @@ analytics <- R6::R6Class(
             private$data$client$usertype <- usertype
             private$data$meta$sign_in_count <- private$data$meta$sign_in_count + 1
             private$data$logged <- TRUE
-            private$data$data[[length(private$data$data) + 1]] <- list(
+            private$data$history[[length(private$data$history) + 1]] <- list(
                 time = Sys.time(),
                 id = "login",
                 item = "user logged in",

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -10,7 +10,7 @@ app_server <- function(input, output, session) {
     logged <- reactiveVal(FALSE)
     initProg <- reactiveVal(TRUE)
     pageCounter <- reactiveVal(1)
-    analytics <- analytics$new(version = "0.0.3", active = FALSE)
+    analytics <- analytics$new(version = "0.0.3", active = TRUE)
     response <- mod_login_server("signin-form", accounts, logged, analytics)
  
     # output pages


### PR DESCRIPTION
Minor fixes to analytics module

- Sign in data was logged to `data`, which was replaced by `history`
- In the server, set `active` status to `TRUE`